### PR TITLE
Emit a warning when loading NIFs

### DIFF
--- a/src/concuerror.hrl
+++ b/src/concuerror.hrl
@@ -93,9 +93,10 @@
    autoload_and_log(Module, Logger),
    case concuerror_loader:load(Module) of
      already_done -> ok;
-     ok ->
+     {ok, Warn} ->
        ?log(Logger, ?linfo,
             "Automatically instrumented module ~p~n", [Module]),
+       _ = [?log(Logger, ?lwarning, W, []) || W <- Warn],
        ok;
      fail ->
        ?log(Logger, ?lwarning,

--- a/tests-real/suites/options/other-tests
+++ b/tests-real/suites/options/other-tests
@@ -92,4 +92,8 @@ testing "Log messages are shown for option errors"
 ! concuerror_console -module foo
 consolehas "Parsing '-module' as '--module odule' (add a dash if this is not desired)"
 
+testing "Warn when erlang:load_nif/2 is detected"
+concuerror_console -f src/load_nif.erl
+consolehas "Module load_nif contains a call to erlang:load_nif/2."
+
 . footer

--- a/tests-real/suites/options/src/load_nif.erl
+++ b/tests-real/suites/options/src/load_nif.erl
@@ -1,0 +1,11 @@
+-module(load_nif).
+-export([test/0]).
+
+-on_load(init/0).
+
+init() ->
+  catch erlang:load_nif("", no),
+  ok.
+
+test() ->
+  ok.

--- a/tests/suites/advanced_tests/src/send_order.erl
+++ b/tests/suites/advanced_tests/src/send_order.erl
@@ -1,0 +1,30 @@
+-module(send_order).
+-export([test1/0, test2/0]).
+
+%%% See https://github.com/parapluu/Concuerror/issues/77
+
+-export([scenarios/0]).
+-export([exceptional/0]).
+
+scenarios() ->
+  [{T, inf, dpor, crash} || T <- [test1, test2]].
+
+exceptional() ->
+  fun(_Expected, Actual) ->
+      Cmd = "grep \"Module crypto contains a call to erlang:load_nif/2.\" ",
+      [_,_,_|_] = os:cmd(Cmd ++ Actual),
+      true
+  end.
+
+test1() ->
+    Orig = [I || <<I>> <= crypto:strong_rand_bytes(5)],
+    Master = self(),
+    [spawn(fun() -> Master ! I end) || I <- Orig],
+    Orig = [receive I -> I end || _ <- Orig].
+
+test2() ->
+    Orig = [I || <<I>> <= crypto:strong_rand_bytes(5)],
+    Master = self(),
+    Sorted = lists:sort(Orig),
+    [spawn(fun() -> timer:sleep(I), Master ! I end) || I <- Orig],
+    Sorted = [receive I -> I end || _ <- Orig].


### PR DESCRIPTION
Stateless systematic testing requires that any state of the program
that has already been visited can be reached again just by making the
same scheduling choices. In order for this to work, one must control
all other sources of nondeterminism. NIFs cannot, in general, be
guaranteed to return the same result for each call with the same
arguments, nor can they be intercepted.

With this patch Concuerror should emit a warning when trying to run
code that may contain NIFs.

BUG: The warning is currently not emitted because the on_load function
is called from the code_server process, which is uninstrumented.

Related issue: parapluu/Concuerror#77