### PR TITLE
Pre-spawn a number of processes

### DIFF
--- a/src/concuerror.erl
+++ b/src/concuerror.erl
@@ -38,8 +38,12 @@ start(Options, LogMsgs) ->
   Estimator = concuerror_estimator:start_link(Options),
   LoggerOptions = [{estimator, Estimator},{processes, Processes}|Options],
   Logger = concuerror_logger:start(LoggerOptions),
+  ProcessSpawner = concuerror_process_spawner:start(Options),
   _ = [?log(Logger, Level, Format, Args) || {Level, Format, Args} <- LogMsgs],
-  SchedulerOptions = [{logger, Logger}|LoggerOptions],
+  SchedulerOptions = 
+    [ {logger, Logger}
+    , {process_spawner, ProcessSpawner}
+      | LoggerOptions],
   {Pid, Ref} =
     spawn_monitor(concuerror_scheduler, run, [SchedulerOptions]),
   Reason = receive {'DOWN', Ref, process, Pid, R} -> R end,
@@ -53,6 +57,7 @@ start(Options, LogMsgs) ->
   ?trace(Logger, "Reached the end!~n",[]),
   ExitStatus = concuerror_logger:stop(Logger, SchedulerStatus),
   concuerror_estimator:stop(Estimator),
+  concuerror_process_spawner:stop(ProcessSpawner),
   ets:delete(Processes),
   ExitStatus.
 

--- a/src/concuerror_options.erl
+++ b/src/concuerror_options.erl
@@ -150,6 +150,9 @@ options() ->
     "                exploration is too slow. Use 'optimal' if a lot of~n"
     "                interleavings are reported as sleep-set blocked.~n"
     "- 'persistent': Using persistent sets. Do not use."}
+  ,{max_processes, [erlang], undefined, {integer, 20},
+    "Maximum number of processes",
+    "The maximum number of processes used by your test."}
   ,{optimal, [por], undefined, boolean,
     "Synonym for `--dpor optimal (true) | source (false)`.",
     nolong}
@@ -312,7 +315,8 @@ check_validity(Key) ->
       when
         Key =:= after_timeout;
         Key =:= depth_bound;
-        Key =:= print_depth
+        Key =:= print_depth;
+        Key =:= max_processes
         ->
       {fun(V) -> V > 0 end, "a positive integer"};
     dpor ->

--- a/src/concuerror_process_spawner.erl
+++ b/src/concuerror_process_spawner.erl
@@ -1,0 +1,118 @@
+%% @doc A server that pre-spawns processes used in a test.
+%%
+%% The reason for this server's existence is to coordinate the
+%% spawning of processes. This is required when Concuerror is using
+%% slave nodes to explore schedulings in parallel, to ensure that the
+%% same (local) PIDs are used in all such nodes.
+
+-module(concuerror_process_spawner).
+
+%% Interface to concuerror.erl
+-export([start/1, stop/1, spawn_link/2]).
+-export([explain_error/1]).
+
+%%-----------------------------------------------------------------------------
+
+-include("concuerror.hrl").
+
+%%-----------------------------------------------------------------------------
+
+-ifdef(BEFORE_OTP_17).
+-type process_queue() :: queue().
+-else.
+-type process_queue() :: queue:queue(pid()).
+-endif.
+
+-record(spawner_state, {
+          max_processes :: non_neg_integer(),
+          process_queue :: process_queue()
+         }).
+
+%%-----------------------------------------------------------------------------
+
+-spec start(concuerror_options:options()) -> pid().
+
+start(Options) ->
+  Parent = self(),
+  Fun =
+    fun() ->
+        State = initialize_spawner(Options),
+        Parent ! process_gen_ready,
+        spawner_loop(State)
+    end,
+  P = spawn_link(Fun),
+  receive
+    process_gen_ready -> P
+  end.
+
+initialize_spawner(Options) ->
+  MaxProcesses = ?opt(max_processes, Options),
+  Fun = fun() -> wait_activation() end,
+  AvailableProcesses = [spawn_link(Fun) || _ <- lists:seq(1, MaxProcesses)],
+  #spawner_state{
+     max_processes = MaxProcesses,
+     process_queue = queue:from_list(AvailableProcesses)
+    }.
+
+wait_activation() ->
+  receive
+    {activate, {Module, Name, Args}} ->
+      erlang:apply(Module, Name, Args);
+    stop -> ok
+  end.
+
+spawner_loop(State) ->
+  #spawner_state{process_queue = ProcessQueue} = State,
+  receive
+    {Caller, get_new_process} ->
+      case queue:out(ProcessQueue) of
+        {empty, ProcessQueue} ->
+          Caller ! {process_limit_exceeded, State#spawner_state.max_processes},
+          spawner_loop(State);
+        {{value, Process}, NewProcessQueue} ->
+          %% Needed to propagate crash messages through correct path
+          %% (not via spawner).
+          unlink(Process),
+          Caller ! {new_process, Process},
+          spawner_loop(State#spawner_state{process_queue = NewProcessQueue})
+      end;
+    {Pid, cleanup} ->
+      _ = [IdleProcess ! stop || IdleProcess <- queue:to_list(ProcessQueue)],
+      Pid ! done
+  end.
+
+%%-----------------------------------------------------------------------------
+
+-spec spawn_link(pid(), {module(), atom(), [term()]}) -> pid().
+
+spawn_link(ProcessSpawner, MFArgs) ->
+  ProcessSpawner ! {self(), get_new_process},
+  receive
+    {new_process, Pid} ->
+      %% Needed to properly propagate crash messages!
+      link(Pid),
+      Pid ! {activate, MFArgs},
+      Pid;
+    {process_limit_exceeded, MaxProcesses} ->
+      ?crash({process_limit_exceeded, MaxProcesses})
+  end.
+
+%%-----------------------------------------------------------------------------
+
+-spec stop(pid()) -> 'ok'.
+
+stop(ProcessSpawner) ->
+  ProcessSpawner ! {self(), cleanup},
+  receive
+    done -> ok
+  end.
+
+%%-----------------------------------------------------------------------------
+
+-spec explain_error(term()) -> string().
+
+explain_error({process_limit_exceeded, MaxProcesses}) ->
+  io_lib:format(
+    "Your test is using more than ~w processes (--max_processes)."
+    " You can specify a higher limit, but consider using fewer processes.",
+    [MaxProcesses]).

--- a/tests/suites/advanced_tests/src/vjeko_peer.erl
+++ b/tests/suites/advanced_tests/src/vjeko_peer.erl
@@ -20,6 +20,7 @@
 
 -concuerror_options_forced(
     [ {depth_bound, 100000}
+    , {max_processes, 30}
     , {non_racing_system, [user]}
     , {keep_going, true}
     , {interleaving_bound, 100}

--- a/tests/suites/basic_tests/results/static_spawns-test1-inf-optimal.txt
+++ b/tests/suites/basic_tests/results/static_spawns-test1-inf-optimal.txt
@@ -1,0 +1,49 @@
+Concuerror v0.18-285-gab3ca8 started at 03 May 2018 18:26:28
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{static_spawns,test1,[]}},
+   {exclude_module,[]},
+   {files,["/home/panagiotis/Documents/sxoli/dipl/Concuerror/tests/suites/basic_tests/src/static_spawns.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {max_processes,5},
+   {non_racing_system,[]},
+   {parallel,false},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Exploration completed!
+  No errors found!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /home/panagiotis/Documents/sxoli/dipl/Concuerror/tests/results/basic_tests/results/static_spawns-test1-inf-optimal.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module static_spawns
+* Automatically instrumented module erlang
+
+################################################################################
+Done at 03 May 2018 18:26:28 (Exit status: ok)
+  Summary: 0 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/results/static_spawns-test2-inf-optimal.txt
+++ b/tests/suites/basic_tests/results/static_spawns-test2-inf-optimal.txt
@@ -1,0 +1,70 @@
+Concuerror v0.18-285-gab3ca8 started at 03 May 2018 18:26:28
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{static_spawns,test2,[]}},
+   {exclude_module,[]},
+   {files,["/home/panagiotis/Documents/sxoli/dipl/Concuerror/tests/suites/basic_tests/src/static_spawns.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {max_processes,5},
+   {non_racing_system,[]},
+   {parallel,false},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Concuerror crashed
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<static_spawns.0.54810195>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<static_spawns.0.54810195>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<static_spawns.0.54810195>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<static_spawns.0.54810195>,[]])
+    in erlang.erl line 2687
+################################################################################
+Exploration completed!
+################################################################################
+Errors:
+--------------------------------------------------------------------------------
+* Your test is using more than 5 processes (--max_processes). Increase the limit or consider using fewer processes.
+
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /home/panagiotis/Documents/sxoli/dipl/Concuerror/tests/results/basic_tests/results/static_spawns-test2-inf-optimal.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module static_spawns
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 03 May 2018 18:26:28 (Exit status: fail)
+  Summary: 1 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/src/lid_test.erl
+++ b/tests/suites/basic_tests/src/lid_test.erl
@@ -15,6 +15,8 @@
 -export([scenarios/0]).
 -export([test/0]).
 
+-concuerror_options_forced([{max_processes, 1050}]).
+
 scenarios() ->
     [{test, inf, dpor}].
 

--- a/tests/suites/basic_tests/src/static_spawns.erl
+++ b/tests/suites/basic_tests/src/static_spawns.erl
@@ -1,0 +1,25 @@
+-module(static_spawns).
+-export([scenarios/0]).
+-export([test1/0, test2/0]).
+
+%
+% Tests that statically spawning processes works
+%
+
+-concuerror_options_forced([{max_processes, 5}]).
+
+scenarios() -> [{test1, inf, optimal},
+				{test2, inf, optimal, crash}].
+
+% 5 processes are getting spawned in total
+test1() ->
+    spawn_procs(4).
+
+% 6 processes are getting spawned in total
+test2() ->
+	spawn_procs(5).
+
+spawn_procs(0) -> ok;
+spawn_procs(N) ->
+	spawn(fun() -> ok end),
+	spawn_procs(N-1).

--- a/tests/suites/dpor_tests/src/file_system_example.erl
+++ b/tests/suites/dpor_tests/src/file_system_example.erl
@@ -5,6 +5,8 @@
 -export([test14/0, test16/0, test18/0, test24/0]).
 -export([scenarios/0]).
 
+-concuerror_options_forced([{max_processes, 100}]).
+
 scenarios() -> [{test, inf, dpor}].
 
 -define(NUMBLOCKS, 26).

--- a/tests/suites/dpor_tests/src/proxy.erl
+++ b/tests/suites/dpor_tests/src/proxy.erl
@@ -3,7 +3,7 @@
 -export([proxy/0]).
 -export([scenarios/0]).
 
--concuerror_options_forced([{depth_bound, 1000}, {instant_delivery, false}]).
+-concuerror_options_forced([{depth_bound, 1000}, {instant_delivery, false}, {max_processes, 150}]).
 
 scenarios() -> [{?MODULE, inf, dpor}].
 

--- a/tests/suites/dpor_tests/src/proxy2.erl
+++ b/tests/suites/dpor_tests/src/proxy2.erl
@@ -3,6 +3,8 @@
 -export([proxy2/0]).
 -export([scenarios/0]).
 
+-concuerror_options_forced([{max_processes, 150}]).
+
 scenarios() -> [{?MODULE, inf, dpor}].
 
 proxy2() ->


### PR DESCRIPTION
## Summary

This is a step towards the parallelisation. Parallel schedulers will be running on slave nodes and use the spawner to ensure that the local pids are identical.

Fixes #4.

## Checklist

* [x] Has tests (or doesn't need them)
* [ ] Updates CHANGELOG (or too minor)